### PR TITLE
fix: Correct Docker build by enabling standalone output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,12 +20,12 @@ FROM base AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production
-ENV NEXT_TELEMETRY_DISABLED 1
+ENV NEXT_TELEMETRY_DISABLED=1
 ENV PORT=3000
 
 COPY --from=builder /app/public ./public
-COPY --from=builder --chown=nextjs:nodejs ./.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs ./.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 USER nextjs
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: "standalone",
   eslint: {
     ignoreDuringBuilds: true,
   },


### PR DESCRIPTION
The previous Docker build was failing because the Next.js application was not configured to produce a standalone output, and the Dockerfile was referencing incorrect paths.

This commit addresses the issue by:
- Updating `next.config.mjs` to include the `output: 'standalone'` option.
- Correcting the `COPY` paths in the `Dockerfile` to align with the standalone output structure.

These changes should resolve the build error and allow the Docker image to be built successfully.